### PR TITLE
Small improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,4 @@ COPY resources/listing.html /usr/lib/node_modules/reveal-md/template/
 
 EXPOSE 1948
 
-ENTRYPOINT ["reveal-md"]
-
-CMD ["/usr/src/app", "-w", "--theme", "cs"]
+CMD ["sh", "-c", "reveal-md /usr/src/app -w --theme cs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.4
 
-RUN mkdir -p /usr/src/app
-
 WORKDIR /usr/src/app
 
 RUN apk update && apk add nodejs

--- a/resources/reveal.html
+++ b/resources/reveal.html
@@ -57,7 +57,8 @@
               progress: true,
               history: true,
               center: true,
-              transition: 'default',
+              slideNumber: true,
+              transition: 'none',
               dependencies: deps
             };
 

--- a/resources/reveal.html
+++ b/resources/reveal.html
@@ -16,12 +16,12 @@
     <body>
 
         <div class="reveal">
-		<div class="slides">
-			<div class="footer">
-				<img class="logotyp" src="images/cs.png">
-			</div>	
-			{{{slides}}}
-		</div>
+          <div class="slides">
+            <div class="footer">
+              <img class="logotyp" src="images/cs.png">
+            </div>
+            {{{slides}}}
+          </div>
         </div>
 
         <script src="lib/js/head.min.js"></script>

--- a/slides.md
+++ b/slides.md
@@ -1,8 +1,5 @@
 ---
 title: Title of the talk - with a subtitle
-revealOptions:
-    transition: 'none'
-    slideNumber: 'true'
 ---
 
 # Title of the talk


### PR DESCRIPTION
- Fix indentation
- Make CTRL+C work by wrapping reveal-md in a shell (I guess node doesn't handle the INT signal)
- Move options from boilerplate in YAML front-matter to the reveal.js file.